### PR TITLE
Blog post folders with YYYYMMDD-- prefix, removed in slug

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -54,7 +54,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
   if (node.internal.type === `MarkdownRemark`) {
-    const value = createFilePath({ node, getNode })
+    const value = createFilePath({ node, getNode }).replace(/\d{8}--/, '')
     createNodeField({
       name: `slug`,
       node,


### PR DESCRIPTION
Don't want the /blog/ folder to get filled up with unsortable entries. This allows add `YYYYMMDD--` prefix to all blog post folder names, but filters that out in the slug.

e.g. `20190215--test-post` folder will have the url of `/test-post`.