### PR TITLE
Remove unnecessary call to stylesheet

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,3 @@
 // custom typefaces
 import "typeface-vollkorn"
 import "typeface-roboto-condensed"
-
-// stylesheet
-import "./src/styles/global.css"


### PR DESCRIPTION
Left in a mistaken call to the deleted global.css  in gatsby-browser.js.